### PR TITLE
ImageStream can't be ViewScoped

### DIFF
--- a/src/main/java/lt/vu/mif/ui/controller/ProductEditController.java
+++ b/src/main/java/lt/vu/mif/ui/controller/ProductEditController.java
@@ -35,8 +35,9 @@ public class ProductEditController {
     private ICategoryHelper categoryHelper;
     @Autowired
     private IImageHelper imageHelper;
+    @Autowired
+    private ImageInMemoryStreamer imageInMemoryStreamer;
 
-    private ImageInMemoryStreamer imageInMemoryStreamer = new ImageInMemoryStreamer();
     private ProductView productView;
     private Part uploadedFile;
     private boolean showSuccessMessage;

--- a/src/main/java/lt/vu/mif/ui/view/ImageInMemoryStreamer.java
+++ b/src/main/java/lt/vu/mif/ui/view/ImageInMemoryStreamer.java
@@ -1,8 +1,10 @@
 package lt.vu.mif.ui.view;
 
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseId;
 import javax.inject.Named;
@@ -12,7 +14,8 @@ import org.primefaces.model.StreamedContent;
 
 @Named
 @Getter
-public class ImageInMemoryStreamer {
+@SessionScoped
+public class ImageInMemoryStreamer implements Serializable {
 
     private Map<Long, InputStream> imagesInMemory = new HashMap<>();
 

--- a/src/main/webapp/templates/admin/edit-product.xhtml
+++ b/src/main/webapp/templates/admin/edit-product.xhtml
@@ -167,7 +167,7 @@
                                 <div class="columns small-12 medium-3">
                                     <div class="box-for-buttons-on-image">
                                         <p:graphicImage
-                                                value="#{productEditController.imageInMemoryStreamer.image}"
+                                                value="#{imageInMemoryStreamer.image}"
                                                 class="thumbnail">
                                             <f:param name="id" value="#{image.id}"/>
                                         </p:graphicImage>


### PR DESCRIPTION
Probably RISKY fix. Added @SessionScoped on inMemory Image streamer. (as long it's not used anywhere else in same session it should be fine I guess)
Issue detailed:
Image rendering happens in 2 stages, **1st some initialization**, **2nd the rendering**
**2nd stage** is called from different thread, which means ViewScoped bean can't be accessed, this could never have worked. (InMemoryImageStreamer was created directly in ProductEditController which must be ViewScoped for this workflow.)